### PR TITLE
Hw front week11

### DIFF
--- a/session/front/week11/src/apis/blog/axios/index.js
+++ b/session/front/week11/src/apis/blog/axios/index.js
@@ -19,3 +19,24 @@ export const deletePost = async (postId) => {
   const { data } = await axios.delete(`api/posts/${postId}`);
   return data;
 };
+
+// 프론트 11주차 과제
+export const postSignup = async (username, password) => {
+  const { data } = await axios.post(`/api/signup`, username, password);
+  return data;
+};
+
+export const updateProfile = async (username) => {
+  const { data } = await axios.put(`/api/editInfo`, username);
+  return data;
+};
+
+export const myPageFetch = async (userId) => {
+  const { data } = await axios.get(`api/myPageFetch/${userId}`);
+  return data;
+};
+
+export const deleteUser = async (userId) => {
+  const { data } = await axios.delete(`api/delete/${userId}`);
+  return data;
+};

--- a/session/front/week11/src/apis/blog/queries/index.js
+++ b/session/front/week11/src/apis/blog/queries/index.js
@@ -3,6 +3,10 @@ import { createPost } from "../axios";
 import { updatePost } from "../axios";
 import { getPost } from "../axios";
 import { deletePost } from "../axios";
+import { postSignup } from "../axios";
+import { updateProfile } from "../axios";
+import { myPageFetch } from "../axios";
+import { deleteUser } from "../axios";
 
 export const useCreatePost = () => {
   return useMutation({
@@ -34,6 +38,55 @@ export const useDeletePost = () => {
     onSuccess: () => {
       alert("게시글이 삭제되었습니다.");
       queryClient.invalidateQueries("postList");
+    },
+  });
+};
+
+// 프론트 11주차 과제
+// 회원가입 (sign up)
+export const usePostSignup = () => {
+  return useMutation({
+    mutationFn: ({ username, password }) => postSignup(username, password),
+    onSuccess: () => {
+      alert("환영합니다!");
+    },
+    enabled: !!username && !!password,
+  });
+};
+
+// 개인정보 수정 (update profile)
+export const useUpdateProfile = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (username) => updateProfile(username),
+    onSuccess: () => {
+      queryClient.invalidateQueries("myPage");
+    },
+  });
+};
+
+// 마이페이지 조회 (my page fetch)
+export const useMyPageFetch = (userId) => {
+  return useQuery({
+    queryKey: ["profile", userId],
+    queryFn: () => myPageFetch(userId),
+    staleTime: 30000,
+    cacheTime: 300000,
+  });
+};
+
+// 회원 정보 삭제 (delete user)
+export const useDeleteUser = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (userId) => {
+      deleteUser(userId);
+    },
+    // 1시간동안 관련 데이터 유지
+    cacheTime: 3600000,
+    onSuccess: () => {
+      alert("계정이 삭제되었습니다!");
+      queryClient.invalidateQueries("mypage");
     },
   });
 };


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #47 

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
세션에서 실습한 내용을 바탕으로 
1) 회원가입, 2) 개인정보 수정, 3) 마이페이지 조회, 4) 회원 삭제의
api통신 함수를 React Query로 작성하기

## 1️⃣ 회원가입 
```
// axios
export const postSignup = async (username, password) => {
  const { data } = await axios.post(`/api/users`, username, password);
  return data;
};

// query
export const usePostSignup = () => {
  return useMutation({
    mutationFn: ({ username, password }) => postSignup(username, password),
    onSuccess: () => {
      alert("환영합니다!");
    },
    enabled: !!username && !!password,
  });
};
```
회원가입은 
username과 password를 모두 입력 받아 data에 post 해야 하기 때문에 request body에 적었습니다
그리고 데이터를 추가(변화)하는 것에 해당하기 때문에 useMutation을 사용했습니다. 
username, password의 값이 변하면 postSingUp 함수를 호출해서 username과 password값을 매개변수로 넘겨주고, 
onSuccess를 사용해서 성공시 "환영합니다!"라는 알림이 뜨게 설정 했습니다.
그리고 username과 password 값을 모두 입력한 경우만 동작하도록 enabled 설정을 했습니다.


## 2️⃣ 개인정보 수정
```
// axios
export const updateProfile = async (username) => {
  const { data } = await axios.put(`/api/users`, username);
  return data;
};

// query
export const useUpdateProfile = () => {
  const queryClient = useQueryClient();
  return useMutation({
    mutationFn: (username) => updateProfile(username),
    onSuccess: () => {
      queryClient.invalidateQueries("myPage");
    },
  });
};
```
개인정보 수정은
username만 수정할 수 있는 경우를 고려해서 입력 받은 username을 request body로  put 요청을 보냈습니다.
그리고 데이터 값을 수정하는 것에 해당하기 때문에 useMutation을 사용했습니다.
username의 값이 변경되면 username값을 매개변수로 넘겨 updateProfile함수를 호출합니다.
onSuccess 옵션을 통해 invalidateQueries를 사용해서 mypage와 관련된 데이터를 무효화시키고 데이터를 새로고침하는 기능을 추가했습니다.

## 3️⃣ 마이페이지 조회
```
// axios
export const myPageFetch = async (userId) => {
  const { data } = await axios.get(`api/users/${userId}`);
  return data;
};

// query
export const useMyPageFetch = (userId) => {
  return useQuery({
    queryKey: ["mypage", userId],
    queryFn: () => myPageFetch(userId),
    staleTime: 30000,
    cacheTime: 300000,
  });
};
```
마이페이지 조회는 별도의 request body가 필요 없기 때문에 없이 get요청을 합니다.
그리고 데이터의 조회에 해당하기 때문에 useQuery 훅을 사용해야 합니다. 
queryKey에 배열 값을 줘서 userId에 따라 다른 프로필 데이터를 구분하고 캐싱하게 설정했습니다.
myPageFetch(userId) 함수를 호출하여 데이터를 가져오고, 
데이터를 불러온 후 30초 동안은 새로운 데이터를 불러오지 않고 캐시된 데이터를 사용하도록 staleTime을 설정했습니다.
cacheTime을 설정해서 5분간 캐시가 유지되도록 설정했습니다.

## 4️⃣ 회원 정보 삭제
```
// axios
export const deleteUser = async (userId) => {
  const { data } = await axios.delete(`api/users/${userId}`);
  return data;
};

// query
export const useDeleteUser = () => {
  const queryClient = useQueryClient();
  return useMutation({
    mutationFn: (userId) => {
      deleteUser(userId);
    },
    // 1시간동안 관련 데이터 유지
    cacheTime: 3600000,
    onSuccess: () => {
      alert("계정이 삭제되었습니다!");
      queryClient.invalidateQueries("mypage");
    },
  });
};
```
회원 정보 삭제는 
데이터 값을 수정하는 것에 해당하기 때문에 useMutation을 사용했습니다.
userId를 인수로 받아 deleteUser(userId)를 호출하여 해당 사용자를 삭제합니다.
1시간동안 회원 정보가 캐시에 남아있도록 설정했고,
onSuccess 옵션을 통해 invalidateQueries를 사용해서 mypage와 관련된 모든 캐시 데이터를 무효화시키고 데이터를 새로고침하는 기능을 추가했습니다.


## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

궁금한점: staleTime이랑 cacheTime은 항상 같이 써줘야 하나요? 아니면 둘 중 하나만 써도 되는건가요? 궁금합니댜,,
